### PR TITLE
Public access modifiers added

### DIFF
--- a/Sources/SwiftLibModbus/SwiftLibModbus.swift
+++ b/Sources/SwiftLibModbus/SwiftLibModbus.swift
@@ -10,26 +10,26 @@
 import Foundation
 import CModbus
 
-enum FunctionType {
+public enum FunctionType {
     case kInputBits
     case kBits
     case kInputRegisters
     case kRegisters
 }
 
-class SwiftLibModbus: NSObject {
+public class SwiftLibModbus: NSObject {
 
     var mb: OpaquePointer?
     var modbusQueue: DispatchQueue?
     var ipAddress: NSString?
 
-    init(ipAddress: NSString, port: Int32, device: Int32) {
+    public init(ipAddress: NSString, port: Int32, device: Int32) {
         super.init()
         modbusQueue = DispatchQueue(label: "com.iModbus.modbusQueue", attributes: .concurrent)
         let _ = self.setupTCP(ipAddress: ipAddress, port: port, device: device)
     }
 
-    func setupTCP(ipAddress: NSString, port: Int32, device: Int32) -> Bool {
+    public func setupTCP(ipAddress: NSString, port: Int32, device: Int32) -> Bool {
         self.ipAddress = ipAddress
         mb = modbus_new_tcp(ipAddress.cString(using: String.Encoding.ascii.rawValue) , port)
         var modbusErrorRecoveryMode = modbus_error_recovery_mode(0)
@@ -39,7 +39,7 @@ class SwiftLibModbus: NSObject {
         return true
     }
 
-    func connectWithError(_ error: NSError) -> Bool {
+    public func connectWithError(_ error: NSError) -> Bool {
         let ret = modbus_connect(mb!)
         if ret == -1 {
             var error = error
@@ -49,7 +49,7 @@ class SwiftLibModbus: NSObject {
         return true
     }
 
-    func connect(success: @escaping () -> Void, failure: @escaping (NSError) -> Void) {
+    public func connect(success: @escaping () -> Void, failure: @escaping (NSError) -> Void) {
         modbusQueue?.async {
             let ret = modbus_connect(self.mb!)
             if ret == -1 {
@@ -65,11 +65,11 @@ class SwiftLibModbus: NSObject {
         }
     }
 
-    func disconnect() {
+    public func disconnect() {
         modbus_close(mb!)
     }
 
-    func writeType(type: FunctionType, address: Int32, value: Int32, success: @escaping () -> Void, failure: @escaping (NSError) -> Void) {
+    public func writeType(type: FunctionType, address: Int32, value: Int32, success: @escaping () -> Void, failure: @escaping (NSError) -> Void) {
         if type == .kBits {
             let status = value != 0
             self.writeBit(address: address, status: status,
@@ -95,7 +95,7 @@ class SwiftLibModbus: NSObject {
         }
     }
 
-    func readType(type: FunctionType, startAddress: Int32, count: Int32, success: @escaping ([AnyObject]) -> Void, failure: @escaping (NSError) -> Void) {
+    public func readType(type: FunctionType, startAddress: Int32, count: Int32, success: @escaping ([AnyObject]) -> Void, failure: @escaping (NSError) -> Void) {
         if type == .kInputBits {
             self.readInputBitsFrom(startAddress: startAddress, count: count,
                                    success: { (array: [AnyObject]) -> Void in
@@ -134,7 +134,7 @@ class SwiftLibModbus: NSObject {
         }
     }
 
-    func writeBit(address: Int32, status: Bool, success: @escaping () -> Void, failure: @escaping (NSError) -> Void) {
+    public func writeBit(address: Int32, status: Bool, success: @escaping () -> Void, failure: @escaping (NSError) -> Void) {
         modbusQueue?.async {
             if modbus_write_bit(self.mb!, address, status ? 1 : 0) >= 0 {
                 DispatchQueue.main.async {
@@ -149,7 +149,7 @@ class SwiftLibModbus: NSObject {
         }
     }
 
-    func writeRegister(address: Int32, value: Int32, success: @escaping () -> Void, failure: @escaping (NSError) -> Void) {
+    public func writeRegister(address: Int32, value: Int32, success: @escaping () -> Void, failure: @escaping (NSError) -> Void) {
         modbusQueue?.async {
             if modbus_write_register(self.mb!, address, value) >= 0 {
                 DispatchQueue.main.async {
@@ -164,7 +164,7 @@ class SwiftLibModbus: NSObject {
         }
     }
 
-    func readBitsFrom(startAddress: Int32, count: Int32, success: @escaping ([AnyObject]) -> Void, failure: @escaping (NSError) -> Void) {
+    public func readBitsFrom(startAddress: Int32, count: Int32, success: @escaping ([AnyObject]) -> Void, failure: @escaping (NSError) -> Void) {
         modbusQueue?.async {
             let tab_reg: UnsafeMutablePointer<UInt8> = UnsafeMutablePointer<UInt8>.allocate(capacity: Int(count))
             if modbus_read_bits(self.mb!, startAddress, count, tab_reg) >= 0 {
@@ -184,7 +184,7 @@ class SwiftLibModbus: NSObject {
         }
     }
 
-    func readInputBitsFrom(startAddress: Int32, count: Int32, success: @escaping ([AnyObject]) -> Void, failure: @escaping (NSError) -> Void) {
+    public func readInputBitsFrom(startAddress: Int32, count: Int32, success: @escaping ([AnyObject]) -> Void, failure: @escaping (NSError) -> Void) {
         modbusQueue?.async {
             let tab_reg: UnsafeMutablePointer<UInt8> = UnsafeMutablePointer<UInt8>.allocate(capacity: Int(count))
             if modbus_read_input_bits(self.mb!, startAddress, count, tab_reg) >= 0 {
@@ -205,7 +205,7 @@ class SwiftLibModbus: NSObject {
     }
 
 
-    func readRegistersFrom(startAddress: Int32, count: Int32, success: @escaping ([AnyObject]) -> Void, failure: @escaping (NSError) -> Void) {
+    public func readRegistersFrom(startAddress: Int32, count: Int32, success: @escaping ([AnyObject]) -> Void, failure: @escaping (NSError) -> Void) {
         modbusQueue?.async {
             let tab_reg: UnsafeMutablePointer<UInt16> = UnsafeMutablePointer<UInt16>.allocate(capacity: Int(count))
             if modbus_read_registers(self.mb!, startAddress, count, tab_reg) >= 0 {
@@ -226,7 +226,7 @@ class SwiftLibModbus: NSObject {
         }
     }
 
-    func readInputRegistersFrom(startAddress: Int32, count: Int32, success: @escaping ([AnyObject]) -> Void, failure: @escaping (NSError) -> Void) {
+    public func readInputRegistersFrom(startAddress: Int32, count: Int32, success: @escaping ([AnyObject]) -> Void, failure: @escaping (NSError) -> Void) {
         modbusQueue?.async {
             let tab_reg: UnsafeMutablePointer<UInt16> = UnsafeMutablePointer<UInt16>.allocate(capacity: Int(count))
             if modbus_read_input_registers(self.mb!, startAddress, count, tab_reg) >= 0 {
@@ -246,7 +246,7 @@ class SwiftLibModbus: NSObject {
         }
     }
 
-    func writeRegistersFromAndOn(address: Int32, numberArray: NSArray, success: @escaping () -> Void, failure: @escaping (NSError) -> Void) {
+    public func writeRegistersFromAndOn(address: Int32, numberArray: NSArray, success: @escaping () -> Void, failure: @escaping (NSError) -> Void) {
         modbusQueue?.async {
             let valueArray: UnsafeMutablePointer<UInt16> = UnsafeMutablePointer<UInt16>.allocate(capacity: numberArray.count)
             for i in 0..<numberArray.count {


### PR DESCRIPTION
Public access modifiers are needed when `SwiftLibModbus` package is used by a package that depends on it.